### PR TITLE
Fixed event registration in RCTExNetworkImageManager

### DIFF
--- a/ExImage.ios.js
+++ b/ExImage.ios.js
@@ -1,23 +1,17 @@
 'use strict';
 
-var EdgeInsetsPropType = require('EdgeInsetsPropType');
-var ImageResizeMode = require('ImageResizeMode');
-var ImageStylePropTypes = require('ImageStylePropTypes');
-var NativeMethodsMixin = require('NativeMethodsMixin');
-var NativeModules = require('NativeModules');
-var PropTypes = require('ReactPropTypes');
-var React = require('React');
-var ReactNativeViewAttributes = require('ReactNativeViewAttributes');
-var StyleSheet = require('StyleSheet');
-var StyleSheetPropType = require('StyleSheetPropType');
+const React = require('react-native');
+const {EdgeInsetsPropType, ImageResizeMode, ImageStylePropTypes, NativeMethodsMixin, NativeModules,
+        PropTypes, StyleSheet, requireNativeComponent} = React;
 
-var flattenStyle = require('flattenStyle');
-var invariant = require('invariant');
-var merge = require('merge');
-var requireNativeComponent = require('requireNativeComponent');
-var resolveAssetSource = require('resolveAssetSource');
-var verifyPropTypes = require('verifyPropTypes');
-var warning = require('warning');
+const StyleSheetPropType        = require('react-native/Libraries/StyleSheet/StyleSheetPropType');
+const flattenStyle              = require('react-native/Libraries/StyleSheet/flattenStyle');
+const ReactNativeViewAttributes = require('react-native/Libraries/ReactNative/ReactNativeViewAttributes');
+const resolveAssetSource        = require('react-native/Libraries/Image/resolveAssetSource');
+const verifyPropTypes           = require('react-native/Libraries/ReactIOS/verifyPropTypes');
+const merge                     = require('react-native/Libraries/vendor/core/merge.js');
+const invariant                 = require('react-native/node_modules/react-tools/src/shared/vendor/core/invariant.js');
+const warning                   = require('react-native/node_modules/react-tools/src/shared/vendor/core/warning.js');
 
 var ExImage = React.createClass({
   propTypes: {
@@ -26,24 +20,24 @@ var ExImage = React.createClass({
      * could be an http address, a local file path, or the name of a static image
      * resource (which should be wrapped in the `require('image!name')` function).
      */
-    source: PropTypes.shape({
+    source                : PropTypes.shape({
       uri: PropTypes.string,
     }),
     /**
      * A static image to display while downloading the final image off the
      * network.
      */
-    defaultSource: PropTypes.shape({
+    defaultSource         : PropTypes.shape({
       uri: PropTypes.string,
     }),
     /**
      * Whether this element should be revealed as an accessible element.
      */
-    accessible: PropTypes.bool,
+    accessible            : PropTypes.bool,
     /**
      * Custom string to display for accessibility.
      */
-    accessibilityLabel: PropTypes.string,
+    accessibilityLabel    : PropTypes.string,
     /**
      * When the image is resized, the corners of the size specified
      * by capInsets will stay a fixed size, but the center content and borders
@@ -51,60 +45,60 @@ var ExImage = React.createClass({
      * rounded buttons, shadows, and other resizable assets.  More info on
      * [Apple documentation](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIImage_Class/index.html#//apple_ref/occ/instm/UIImage/resizableImageWithCapInsets)
      */
-    capInsets: EdgeInsetsPropType,
+    capInsets             : EdgeInsetsPropType,
     /**
      * Determines how to resize the image when the frame doesn't match the raw
      * image dimensions.
      */
-    resizeMode: PropTypes.oneOf(['cover', 'contain', 'stretch']),
-    style: StyleSheetPropType(ImageStylePropTypes),
+    resizeMode            : PropTypes.oneOf(['cover', 'contain', 'stretch']),
+    style                 : StyleSheetPropType(ImageStylePropTypes),
     /**
      * A unique identifier for this element to be used in UI Automation
      * testing scripts.
      */
-    testID: PropTypes.string,
+    testID                : PropTypes.string,
     /**
      * Invoked on mount and layout changes with
      *
      *   {nativeEvent: { layout: {x, y, width, height}}}.
      */
-     onLayout: PropTypes.func,
-     /**
-      * Invoked on load start
-      */
-     onLoadStart: PropTypes.func,
-     /**
-      * Invoked on download progress with
-      *
-      *   {nativeEvent: { written, total}}.
-      */
-     onLoadProgress: PropTypes.func,
-     /**
-      * Invoked on load abort
-      */
-     onLoadAbort: PropTypes.func,
-     /**
-      * Invoked on load error
-      *
-      *   {nativeEvent: { error}}.
-      */
-     onLoadError: PropTypes.func,
-     /**
-      * Invoked on load end
-      */
-     onLoaded: PropTypes.func,
-     /**
-      * Progress Indicator background color
-      */
-     loadingBackgroundColor: PropTypes.string,
-     /**
-      * Progress Indicator foreground color
-      */
-     loadingForegroundColor: PropTypes.string,
-     /**
-      * Whether Progress Indicator should be display
-      */
-     progressIndicate: PropTypes.bool,
+    onLayout              : PropTypes.func,
+    /**
+     * Invoked on load start
+     */
+    onLoadStart           : PropTypes.func,
+    /**
+     * Invoked on download progress with
+     *
+     *   {nativeEvent: { written, total}}.
+     */
+    onLoadProgress        : PropTypes.func,
+    /**
+     * Invoked on load abort
+     */
+    onLoadAbort           : PropTypes.func,
+    /**
+     * Invoked on load error
+     *
+     *   {nativeEvent: { error}}.
+     */
+    onLoadError           : PropTypes.func,
+    /**
+     * Invoked on load end
+     */
+    onLoaded              : PropTypes.func,
+    /**
+     * Progress Indicator background color
+     */
+    loadingBackgroundColor: PropTypes.string,
+    /**
+     * Progress Indicator foreground color
+     */
+    loadingForegroundColor: PropTypes.string,
+    /**
+     * Whether Progress Indicator should be display
+     */
+    progressIndicate      : PropTypes.bool,
   },
 
   getDefaultProps: function() {
@@ -147,8 +141,8 @@ var ExImage = React.createClass({
       !(isNetwork && source.isStatic),
       'static image uris cannot start with "http": "' + source.uri + '"'
     );
-    var isStored = !source.isStatic && !isNetwork;
-    var RawImage = isNetwork ? RCTExNetworkImage : RCTExStaticImage;
+    var isStored  = !source.isStatic && !isNetwork;
+    var RawImage  = isNetwork ? RCTExNetworkImage : RCTExStaticImage;
 
     if (this.props.style && this.props.style.tintColor) {
       warning(RawImage === RCTExStaticImage, 'tintColor style only supported on static images.');
@@ -157,14 +151,14 @@ var ExImage = React.createClass({
 
     var nativeProps = merge(this.props, {
       style,
-      tintColor: style.tintColor,
+      tintColor : style.tintColor,
       resizeMode: resizeMode,
     });
     if (isStored) {
       nativeProps.imageInfo = {
         imageTag: source.uri,
         prezSize: {
-          width: style.width || 0,
+          width : style.width || 0,
           height: style.height || 0,
         }
       }
@@ -180,20 +174,20 @@ var ExImage = React.createClass({
 
 var styles = StyleSheet.create({
   base: {
-    overflow: 'hidden',
+    overflow       : 'hidden',
     backgroundColor: '#EFEFEF',
   },
 });
 
 var RCTExNetworkImage = requireNativeComponent('RCTExNetworkImage', null);
-var RCTExStaticImage = requireNativeComponent('RCTExStaticImage', null);
+var RCTExStaticImage  = requireNativeComponent('RCTExStaticImage', null);
 
 var nativeOnlyProps = {
-  src: true,
+  src            : true,
   defaultImageSrc: true,
-  imageTag: true,
-  contentMode: true,
-  imageInfo: true,
+  imageTag       : true,
+  contentMode    : true,
+  imageInfo      : true,
 };
 if (__DEV__) {
   verifyPropTypes(ExImage, RCTExStaticImage.viewConfig, nativeOnlyProps);

--- a/RCTExNetworkImageManager.m
+++ b/RCTExNetworkImageManager.m
@@ -30,4 +30,13 @@ RCT_EXPORT_VIEW_PROPERTY(loadingBackgroundColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(loadingForegroundColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(progressIndicate, BOOL)
 
+- (NSDictionary *)customDirectEventTypes {
+  return @{
+    @"loadStart" : @{@"registrationName" : @"onLoadStart"},
+    @"loadProgress" : @{@"registrationName" : @"onLoadProgress"},
+    @"loadError" : @{@"registrationName" : @"onLoadError"},
+    @"loaded" : @{@"registrationName" : @"onLoaded"}
+  };
+}
+
 @end


### PR DESCRIPTION
Took me a while to firgure out why only loadStart gets invoked, but rest of the events don't work at all.

RCTImageViewManager happens to already registers "loadStart", but since the rest of the event naming are different in this lib (i.e "loadProgress" vs "progress" and so on), they don't work.

Refer to this for reference:

https://github.com/facebook/react-native/blob/61c648d5641da595366801d4a9ef31628cd0eee7/Libraries/Image/RCTImageViewManager.m

This fix makes it work properly on 0.9.0, but won't work on latest >= 0.10.0-rc since they already made a breaking change (from returning NSDictionary to an NSArray), here:

https://github.com/facebook/react-native/blob/master/Libraries/Image/RCTImageViewManager.m

We will need to fix it again if you want to support latest react-native and break compatibility with < 0.10.0.