### PR TITLE
兼容react-native@0.11.0

### DIFF
--- a/RCTExNetworkImageManager.m
+++ b/RCTExNetworkImageManager.m
@@ -43,13 +43,14 @@ RCT_EXPORT_METHOD(clearCache:(RCTResponseSenderBlock)callback) {
     }];
 }
 
-- (NSDictionary *)customDirectEventTypes {
-    return @{
-             @"exLoadStart": @{@"registrationName": @"onExLoadStart"},
-             @"exLoadProgress": @{@"registrationName": @"onExLoadProgress"},
-             @"exLoadError": @{@"registrationName": @"onExLoadError"},
-             @"exLoaded": @{@"registrationName": @"onExLoaded"}
-             };
+- (NSArray *)customDirectEventTypes
+{
+    return @[
+             @"loadStart",
+             @"progress",
+             @"error",
+             @"load",
+             ];
 }
 
 @end


### PR DESCRIPTION
customDirectEventTypes should return an array rather than a dictionary: see 48af214 for details if you depend on this in any of your native component libraries